### PR TITLE
fix: replace bitnami redis subchart with official redis image from ECR Public

### DIFF
--- a/charts/directus/Chart.yaml
+++ b/charts/directus/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
     email: sindieiev@protonmail.ch
     url: https://github.com/directus-labs/helm-chart
 
-version: 1.0.4
+version: 1.1.0
 appVersion: "11.17.4"
 
 dependencies:
@@ -27,7 +27,3 @@ dependencies:
   version: "~18.0.2"
   repository: "https://charts.bitnami.com/bitnami"
   condition: mariadb.enableInstallation
-- name: redis
-  version: "~21.1.11"
-  repository: "https://charts.bitnami.com/bitnami"
-  condition: redis.enabled

--- a/charts/directus/templates/redis.yaml
+++ b/charts/directus/templates/redis.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # Name and service must stay <release>-redis-master: the configmap's
+  # REDIS_HOST points at this hostname (kept from the former bitnami subchart)
+  name: {{ .Release.Name }}-redis-master
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "directus.chart" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: cache
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: cache
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          # Cache mode: no RDB snapshots, no AOF
+          args:
+            - --save
+            - ""
+            - --appendonly
+            - "no"
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis-master
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "directus.chart" . }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cache
+{{- end }}

--- a/charts/directus/values.yaml
+++ b/charts/directus/values.yaml
@@ -139,14 +139,13 @@ mariadb:
   # Set the URL to the mariadb instance, otherwise leave it empty to use one that installed in the cluster
   mariadbURL: ""
 
+# In-chart redis cache (replaces the former bitnami/redis subchart, whose
+# images were retired from free registries). Runs the official Docker redis
+# image in cache mode: no auth, no persistence.
 redis:
   enabled: true
-  auth:
-    enabled: false
   image:
-    registry: public.ecr.aws
-    repository: bitnami/redis
-    tag: 8.0.2-debian-12-r3
-    debug: true
-  replica:
-    replicaCount: 0
+    repository: public.ecr.aws/docker/library/redis
+    tag: "8.0.2"
+    pullPolicy: IfNotPresent
+  resources: {}


### PR DESCRIPTION
## Problem

Redis pods fail with `ImagePullBackOff`: Bitnami retired its free image catalog, so `public.ecr.aws/bitnami/redis` (pinned in #10) no longer pulls.

## Fix

The Bitnami redis *chart* can only run Bitnami-built *images* (its startup/health scripts live under `/opt/bitnami`), so we can't just point it at the official redis image. Instead this drops the bitnami redis subchart entirely and adds a minimal in-chart `Deployment` + `Service` running the official Docker redis image from ECR Public:

- Image: `public.ecr.aws/docker/library/redis:8.0.2` — same redis version as currently pinned
- Same behavior as today: no auth, single instance, cache mode (`--save "" --appendonly no`, emptyDir)
- Service keeps the `<release>-redis-master` name that the configmap's `REDIS_HOST` already targets — no values changes needed in cluster-infra
- Chart version bumped to 1.1.0 (dependency removed)

## Verified

- `helm dependency update` (mariadb only now) + `helm lint` pass
- `helm template` with staging-like values renders both Deployments, correct images, and `REDIS_HOST` matching the new Service name

## Rollout notes

- ArgoCD will prune the bitnami redis StatefulSet/Service and create the new Deployment; brief cache blip, Directus reconnects to the same hostname
- The old StatefulSet's PVC (`redis-data-*-master-0`) is not pruned automatically — delete manually after rollout
- `bitnamilegacy` alternative was considered; team prefers the official image on ECR Public
- The full upstream sync (#13) stays parked for later; it replaces this redis setup again with upstream's approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)